### PR TITLE
Add support for urls from env vars

### DIFF
--- a/Deskfile
+++ b/Deskfile
@@ -1,0 +1,15 @@
+rspec() {
+  dev run --rm aide rspec "$@"
+}
+
+rake() {
+  dev run --rm aide rake "$@"
+}
+
+bundle() {
+  dev run --rm aide bundle "$@"
+}
+
+release_gem() {
+  dev run --rm release_gem
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM 786715713882.dkr.ecr.us-east-1.amazonaws.com/fixuid as fixuid
+
+FROM 786715713882.dkr.ecr.us-east-1.amazonaws.com/ruby-test:3.1.2
+LABEL maintainer="Ryan Schlesinger <ryan@outstand.com>"
+
+COPY --from=fixuid /usr/local/bin/fixuid /usr/local/bin/fixuid
+COPY --from=fixuid /etc/fixuid/config.yml /etc/fixuid/config.yml
+RUN chmod 4755 /usr/local/bin/fixuid
+
+RUN groupadd -g 1000 deploy && \
+      useradd -u 1000 -g deploy -ms /bin/bash deploy && \
+      mv /usr/local/bin/rake /usr/local/bin/rake.back
+
+COPY --chown=deploy:deploy docker/irbrc /home/deploy/.irbrc
+
+COPY docker/tools-entrypoint.sh /tools-entrypoint.sh
+COPY docker/entrypoint.sh /docker-entrypoint.sh
+
+EXPOSE 3000
+EXPOSE 7787
+ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in aide.gemspec
 gemspec
+
+gem "standard", group: [:development, :test]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Aide
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/aide`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+Glue between consul and your rails app.
 
 ## Installation
 
@@ -20,17 +18,14 @@ Or install it yourself as:
 
     $ gem install aide
 
-## Usage
-
-TODO: Write usage instructions here
-
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+- `desk go`
+- `dev build --pull aide`
+- `rspec specs` to run specs
+- Set the application path in the volumes section in `compose.yml`.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/aide.
-
+To release a new version:
+- Update the version number in `version.rb` and commit the result.
+- `dev build --pull aide`
+- `release_gem`

--- a/aide.gemspec
+++ b/aide.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake", "~> 13"
 
   spec.add_runtime_dependency 'diplomat'

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,33 @@
+services:
+  aide:
+    build:
+      context: .
+    image: outstand/aide:dev
+    working_dir: ${WORKSPACE_DIR}
+    volumes:
+      - bundler-data:/usr/local/bundle
+      - .:${WORKSPACE_DIR}
+    ports:
+      - "3000"
+    environment:
+      FIXUID:
+      FIXGID:
+      WORKSPACE_DIR:
+
+  release_gem:
+    image: outstand/aide:dev
+    command: rake release
+    working_dir: /aide
+    environment:
+      FIXUID:
+      FIXGID:
+    volumes:
+      - bundler-data:/usr/local/bundle
+      - .:/aide
+      - ~/.dotfiles/gitconfig:/root/.gitconfig
+      - ~/.dotfiles/gitconfig.user:/root/.gitconfig.user
+      - ~/.ssh/id_rsa:/root/.ssh/id_rsa
+      - ~/.gem:/root/.gem
+
+volumes:
+  bundler-data:

--- a/docker/chown-dirs.sh
+++ b/docker/chown-dirs.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+chown_dir() {
+  dir=$1
+  if [[ -d "${dir}" ]] && [[ "$(stat -c %u:%g "${dir}")" != "${FIXUID}:${FIXGID}" ]]; then
+    echo chown "$dir"
+    chown deploy:deploy "$dir"
+  fi
+}
+
+chown_r_dir() {
+  dir=$1
+  if [[ -d "${dir}" ]] && [[ "$(stat -c %u:%g "${dir}")" != "${FIXUID}:${FIXGID}" ]]; then
+    echo chown -R "$dir"
+    chown -R deploy:deploy "$dir"
+  fi
+}
+
+ensure_dir() {
+  dir=$1
+  mkdir -p "$dir"
+
+  chown_dir "$dir"
+}
+
+chown_r_dir "${WORKSPACE_DIR}"
+
+chown_dir /usr/local/bundle
+ensure_dir /home/deploy/.config/irb

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+su-exec "${FIXUID:?Missing FIXUID var}:${FIXGID:?Missing FIXGID var}" fixuid
+
+"${WORKSPACE_DIR}/docker/chown-dirs.sh"
+set +e
+su-exec deploy touch /home/deploy/.config/irb/irb_history
+su-exec deploy ln -s /home/deploy/.config/irb/irb_history /home/deploy/.irb_history
+set -e
+
+install_tls_certs() {
+  if [ -n "$(ls -A /usr/local/share/ca-certificates)" ]; then
+    echo "Updating ca-certificates"
+    update-ca-certificates
+  fi
+}
+install_tls_certs
+
+if [[ "$1" = 'bundle' ]] || [[ "$1" = 'yarn' ]]; then
+  set -- su-exec deploy "$@"
+  exec "$@"
+fi
+
+set -- su-exec deploy bundle exec "$@"
+
+rm -f "${WORKSPACE_DIR}/tmp/pids/server.pid"
+
+exec "$@"

--- a/docker/irbrc
+++ b/docker/irbrc
@@ -1,0 +1,9 @@
+IRB.conf[:SAVE_HISTORY] = 1000
+IRB.conf[:USE_AUTOCOMPLETE] = false
+
+if Reline
+  Reline.dialog_default_bg_color = :black
+  Reline.dialog_default_fg_color = :red
+  Reline.dialog_highlight_bg_color = :blue
+  Reline.dialog_highlight_fg_color = :white
+end

--- a/docker/tools-entrypoint.sh
+++ b/docker/tools-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+su-exec "${FIXUID:?Missing FIXUID var}:${FIXGID:?Missing FIXGID var}" fixuid > /dev/null 2>&1
+
+"${WORKSPACE_DIR}/docker/chown-dirs.sh" > /dev/null
+
+chown_r_dir() {
+  dir="$1"
+  if [[ -d "${dir}" ]] && [[ "$(stat -c %u:%g "${dir}")" != "${FIXUID}:${FIXGID}" ]]; then
+    echo chown -R "$dir"
+    chown -R deploy:deploy "$dir"
+  fi
+}
+
+ensure_dir() {
+  dir=$1
+  mkdir -p "$dir"
+
+  chown_r_dir "$dir"
+}
+
+ensure_dir /home/deploy/.solargraph/cache > /dev/null
+
+if [ "${1:-}" = "bash" ]; then
+  exec "$@"
+elif [ "${1:-}" = "exit" ]; then
+  exit 0
+fi
+
+set -- su-exec deploy "$@"
+exec "$@"

--- a/lib/aide.rb
+++ b/lib/aide.rb
@@ -11,7 +11,7 @@ module Aide
     attr_writer :services
 
     def service(name)
-      self.services[name] ||= Aide::Service.new(name: name)
+      services[name] ||= Aide::Service.new(name: name)
     end
 
     def config
@@ -19,23 +19,32 @@ module Aide
     end
 
     def configure(&block)
-      self.config.instance_eval(&block)
+      config.instance_eval(&block)
+      load_services
     end
 
     def display_services
-      load_services
-
       puts "Aide Services (Using #{config.service_address_key}):"
-      self.services.each do |name, service|
-        puts "==> #{name}: #{service.address}#{service.port.nil? ? '' : ":#{service.port}"} #{service.display_url(filtered: true)}".strip
+
+      services.each do |name, service|
+        puts "==> #{name}: #{formatted_service(service: service)}"
       end
     end
 
     private
+
     def load_services
-      self.config.services.keys.each do |name|
+      config.services.each_key do |name|
         service(name)
       end
+    end
+
+    def service_port(service:)
+      service.port.nil? ? '' : ":#{service.port}"
+    end
+
+    def formatted_service(service:)
+      "#{service.address}#{service_port(service: service)} #{service.display_url(filtered: true)}".strip
     end
   end
 end

--- a/lib/aide/config.rb
+++ b/lib/aide/config.rb
@@ -25,10 +25,23 @@ module Aide
       self.service_address_method = SERVICE_ADDRESS_METHOD
     end
 
-    def add_service(name:, url:nil, auth:nil, user_key:nil, password_key:nil, protocol_key:nil, multi_url:nil, node:nil, database_key:nil, allow_missing:false)
+    def add_service(
+      name:,
+      url: nil,
+      url_env_key: nil,
+      auth: nil,
+      user_key: nil,
+      password_key: nil,
+      protocol_key: nil,
+      multi_url: nil,
+      node: nil,
+      database_key: nil,
+      allow_missing: false
+    )
       services[name] = {
         name: name,
         url: url,
+        url_env_key: url_env_key,
         multi_url: multi_url,
         auth: auth,
         user_key: user_key,


### PR DESCRIPTION
There's a bit of extra plumbing in this PR to add a lot of our docker stuff.

This is mostly about allowing this:
```
Aide.configure do |config|  
  config.add_service name: :mysql, url_env_key: "AIDE_DATABASE_URL"
end
```

With that I can override the url with that env var. When I later call `Aide.service(:mysql).host`, it'll give me back either the parsed host from the env var or the address of the service in consul.